### PR TITLE
buildsys.mk.in: reorder ${{,FRAMEWORK_}LIBS} and ${LDFLAGS}.

### DIFF
--- a/buildsys.mk.in
+++ b/buildsys.mk.in
@@ -157,7 +157,7 @@ pre-depend:
 ${PROG} ${PROG_NOINST}: ${EXT_DEPS} ${OBJS} ${OBJS_EXTRA}
 	${LINK_STATUS}
 	out="$@"; \
-	if ${LD} -o $@ ${OBJS} ${OBJS_EXTRA} ${LDFLAGS} ${LIBS}; then \
+	if ${LD} -o $@ ${OBJS} ${OBJS_EXTRA} ${LIBS} ${LDFLAGS}; then \
 		${LINK_OK}; \
 	else \
 		${LINK_FAILED}; \
@@ -182,7 +182,7 @@ ${JARFILE}: ${EXT_DEPS} ${JAR_MANIFEST} ${OBJS} ${OBJS_EXTRA}
 ${SHARED_LIB} ${SHARED_LIB_NOINST}: ${EXT_DEPS} ${LIB_OBJS} ${LIB_OBJS_EXTRA}
 	${LINK_STATUS}
 	out="$@"; \
-	if ${LD} -o $@ ${LIB_OBJS} ${LIB_OBJS_EXTRA} ${LIB_LDFLAGS} ${LIB_LDFLAGS_INSTALL_NAME} ${LDFLAGS} ${LIBS}; then \
+	if ${LD} -o $@ ${LIB_OBJS} ${LIB_OBJS_EXTRA} ${LIB_LDFLAGS} ${LIB_LDFLAGS_INSTALL_NAME} ${LIBS} ${LDFLAGS}; then \
 		${LINK_OK}; \
 	else \
 		${LINK_FAILED}; \
@@ -191,7 +191,7 @@ ${SHARED_LIB} ${SHARED_LIB_NOINST}: ${EXT_DEPS} ${LIB_OBJS} ${LIB_OBJS_EXTRA}
 ${FRAMEWORK} ${FRAMEWORK_NOINST}: ${EXT_DEPS} ${LIB_OBJS} ${LIB_OBJS_EXTRA}
 	${LINK_STATUS}
 	out="$@"; \
-	if rm -fr $$out && ${MKDIR_P} $$out && ${MAKE} COPY_HEADERS_IF_SUBDIR=${includesubdir} COPY_HEADERS_DESTINATION=$$PWD/$@/Headers copy-headers-into-framework && if test -f Info.plist; then ${INSTALL} -m 644 Info.plist $$out/Info.plist; fi && if test -f module.modulemap; then ${MKDIR_P} $$out/Modules && ${INSTALL} -m 644 module.modulemap $$out/Modules/module.modulemap; fi && ${LD} -o $$out/$${out%.framework} ${LIB_OBJS} ${LIB_OBJS_EXTRA} ${FRAMEWORK_LDFLAGS} ${FRAMEWORK_LDFLAGS_INSTALL_NAME} ${LDFLAGS} ${FRAMEWORK_LIBS} && ${CODESIGN} -fs ${CODESIGN_IDENTITY} --timestamp=none $$out; then \
+	if rm -fr $$out && ${MKDIR_P} $$out && ${MAKE} COPY_HEADERS_IF_SUBDIR=${includesubdir} COPY_HEADERS_DESTINATION=$$PWD/$@/Headers copy-headers-into-framework && if test -f Info.plist; then ${INSTALL} -m 644 Info.plist $$out/Info.plist; fi && if test -f module.modulemap; then ${MKDIR_P} $$out/Modules && ${INSTALL} -m 644 module.modulemap $$out/Modules/module.modulemap; fi && ${LD} -o $$out/$${out%.framework} ${LIB_OBJS} ${LIB_OBJS_EXTRA} ${FRAMEWORK_LDFLAGS} ${FRAMEWORK_LDFLAGS_INSTALL_NAME} ${FRAMEWORK_LIBS} ${LDFLAGS} && ${CODESIGN} -fs ${CODESIGN_IDENTITY} --timestamp=none $$out; then \
 		${LINK_OK}; \
 	else \
 		rm -fr $$out; false; \
@@ -216,7 +216,7 @@ copy-headers-into-framework:
 
 ${AMIGA_LIB} ${AMIGA_LIB_NOINST}: ${EXT_DEPS} ${AMIGA_LIB_OBJS_START} ${AMIGA_LIB_OBJS} ${AMIGA_LIB_OBJS_EXTRA}
 	${LINK_STATUS}
-	if ${LD} -o $@ ${AMIGA_LIB_OBJS_START} ${AMIGA_LIB_OBJS} ${AMIGA_LIB_OBJS_EXTRA} ${AMIGA_LIB_LDFLAGS} ${LDFLAGS} ${LIBS}; then \
+	if ${LD} -o $@ ${AMIGA_LIB_OBJS_START} ${AMIGA_LIB_OBJS} ${AMIGA_LIB_OBJS_EXTRA} ${AMIGA_LIB_LDFLAGS} ${LIBS} ${LDFLAGS}; then \
 		${LINK_OK}; \
 	else \
 		${LINK_FAILED}; \


### PR DESCRIPTION
`${LDFLAGS}` often contains additional (system) library directories that
also often contain old/already installed versions of the libraries to be
linked and are passed via `${{,FRAMEWORK_}LIBS}`. While
`${{,FRAMEWORK_}LIBS}` pretty much always contains `-Llocal_build_dir` to
make the linker/compiler pick the newly built library for the later
referenced libraries, that location will be overridden and the build
system hence eventually tries to link against the old system library.

This issue is not seen often on Linux-based systems (since they don't
need to supply additional system library directories), but abundant on
others.

For instance, on macOS with MacPorts, LDFLAGS contains `-L${prefix}/lib`
(with `/opt/local` being the default prefix).

This leads to link calls such as these:
```
$LD ... -L${prefix}/lib ... -L../dependent_library -ldependent_library ...
```
which will, sadly, pick `libdependent_library` from `${prefix}/lib` if the
software has been previously installed there.

Reordering both variables will lead to local library directories appear
earlier on the command line and hence have a higher priority, fixing the
issue.